### PR TITLE
Added getter for metrics in InstanceMetrics

### DIFF
--- a/src/main/java/com/microsoft/dhalion/metrics/InstanceMetrics.java
+++ b/src/main/java/com/microsoft/dhalion/metrics/InstanceMetrics.java
@@ -54,8 +54,12 @@ public class InstanceMetrics {
     addMetric(metricName, metricValues);
   }
 
-  public Collection<String> getMetrics() {
+  public Collection<String> getMetricNames() {
     return metrics.keySet();
+  }
+
+  public Map<String, Map<Long, Double>> getMetrics() {
+    return metrics;
   }
 
   /**

--- a/src/test/java/com/microsoft/dhalion/metrics/InstanceMetricsTest.java
+++ b/src/test/java/com/microsoft/dhalion/metrics/InstanceMetricsTest.java
@@ -35,7 +35,7 @@ public class InstanceMetricsTest {
     InstanceMetrics mergedInstanceMetrics
         = InstanceMetrics.merge(instanceMetrics1, instanceMetrics2);
 
-    assertEquals(2, mergedInstanceMetrics.getMetrics().size());
+    assertEquals(2, mergedInstanceMetrics.getMetricNames().size());
     assertNotNull(mergedInstanceMetrics.getMetricValues("m1"));
     assertNotNull(mergedInstanceMetrics.getMetricValues("m2"));
     assertEquals(2, mergedInstanceMetrics.getMetricValues("m1").size());


### PR DESCRIPTION
- The earlier ``getMetrics`` method renamed to ``getMetricNames``.
- The fix was discovered during json serialization of the instance metrics, which requires the getter method for the field ``metrics``. 