### PR TITLE
Assign a reasonable default to previous checkpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.microsoft.dhalion</groupId>
   <artifactId>dhalion</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <packaging>jar</packaging>
 
   <name>Dhalion</name>

--- a/src/main/java/com/microsoft/dhalion/policy/PoliciesExecutor.java
+++ b/src/main/java/com/microsoft/dhalion/policy/PoliciesExecutor.java
@@ -120,7 +120,6 @@ public class PoliciesExecutor {
     this.executor.shutdownNow();
   }
 
-
   public static class ExecutionContext {
     private final MeasurementsTable.Builder measurementsTableBuilder;
     private final SymptomsTable.Builder symptomsTableBuilder;
@@ -139,7 +138,7 @@ public class PoliciesExecutor {
     }
 
     private void captureCheckpoint() {
-      previousCheckpoint = checkpoint != null ? checkpoint : Instant.MIN;
+      previousCheckpoint = checkpoint != null ? checkpoint : Instant.EPOCH;
       checkpoint = policy.getNextCheckpoint();
     }
 


### PR DESCRIPTION
Instant.MIN can cause overflow errors.
Fixes #32