### PR TITLE
Add functionality to execute Resolver without Diagnosis.

### DIFF
--- a/src/main/java/com/microsoft/dhalion/api/IHealthPolicy.java
+++ b/src/main/java/com/microsoft/dhalion/api/IHealthPolicy.java
@@ -69,6 +69,15 @@ public interface IHealthPolicy {
   Collection<Action> executeResolvers(Collection<Diagnosis> diagnosis);
 
   /**
+   * Invoked in the event that the policy should be overridden, this method executes one {@link IResolver} to fix a
+   * single identified issue.
+   *
+   * @param resolver a resolver to be executed
+   * @return actions executed to mitigate health issues
+   */
+  Collection<Action> executeResolver(IResolver resolver);
+
+  /**
    * @return the remaining delay before re-execution of this policy
    */
   Duration getDelay();

--- a/src/main/java/com/microsoft/dhalion/api/IResolver.java
+++ b/src/main/java/com/microsoft/dhalion/api/IResolver.java
@@ -37,6 +37,15 @@ public interface IResolver {
   /**
    * Triggers execution of {@link Action}s which are expected to improved system health.
    *
+   * @return all the actions executed by this resolver
+   */
+  default Collection<Action> resolve() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Triggers execution of {@link Action}s which are expected to improved system health.
+   *
    * @param diagnosis recently identified likely-causes of the observed {@link Symptom}s
    * @return all the actions executed by this resolver to mitigate the problems
    */

--- a/src/main/java/com/microsoft/dhalion/events/EventDispatcher.java
+++ b/src/main/java/com/microsoft/dhalion/events/EventDispatcher.java
@@ -15,7 +15,7 @@ public class EventDispatcher<T> implements EventHandler<T> {
 
   public synchronized void addHandler(EventHandler<T> handler) {
     if (handlers.contains(handler)) {
-      throw new IllegalArgumentException("Duplicate hanlder registration");
+      throw new IllegalArgumentException("Duplicate handler registration");
     }
     handlers.add(handler);
   }

--- a/src/main/java/com/microsoft/dhalion/policy/HealthPolicyImpl.java
+++ b/src/main/java/com/microsoft/dhalion/policy/HealthPolicyImpl.java
@@ -166,6 +166,24 @@ public class HealthPolicyImpl implements IHealthPolicy {
   }
 
   @Override
+  public Collection<Action> executeResolver(IResolver resolver) {
+    if (oneTimeDelay != null && !oneTimeDelay.isAfter(clock.now())) {
+      // reset one time delay timestamp
+      oneTimeDelay = null;
+    }
+
+    Collection<Action> actions = new ArrayList<>();
+    if (!resolvers.contains(resolver)) {
+      return actions;
+    }
+
+    actions = resolver.resolve();
+
+    lastExecutionTimestamp = clock.now();
+    return actions;
+  }
+
+  @Override
   public Duration getDelay() {
     long delay;
     if (lastExecutionTimestamp == null) {


### PR DESCRIPTION
### Summary
In rare cases, the behavior of an `IHealthPolicy` should be overridden. In such a case, an outside system or human operator must take action. This pull request provides an interface so that outside systems may execute `Resolver`s without `Diagnosis`, effectively overriding the behavior of the `IHealthPolicy`.

### Implementation
1. Add method `resolve` to `IResolver` interface. Unimplemented.
2. Add method `executeResolver` to `IHealthPolicy` interface. Unimplemented.
3. Override `executeResolver` method in `HealthPolicyImpl` class.
4. Fixed minor spelling error: `hanlder` -> `handler`.