### PR TITLE
Add ability to customize the injector with custom bootstrap modules

### DIFF
--- a/src/main/java/com/microsoft/dhalion/IBootstrapModule.java
+++ b/src/main/java/com/microsoft/dhalion/IBootstrapModule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * This program is made available under the terms of the MIT License.
+ * See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.dhalion;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+
+/**
+ * {@link IBootstrapModule} should be used to customize the injector with additional bindings required for injecting
+ * the metrics provider and the health policies.
+ */
+public interface IBootstrapModule {
+
+  /**
+   * Dhalion will create a new injector that will inherit all its state from the existing injector and add this module
+   * (and binding definitions) to it.
+   * 
+   * @return {@link Module} with additional binding definitions
+   */
+  default Module get() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+      }
+    };
+  }
+
+  public static class DefaultModule implements IBootstrapModule{}
+}

--- a/src/main/java/com/microsoft/dhalion/conf/Key.java
+++ b/src/main/java/com/microsoft/dhalion/conf/Key.java
@@ -15,12 +15,12 @@ public enum Key {
   POLICY_CONF_SENSOR_DURATION_SUFFIX(".duration"),
   CONF_COMPONENT_NAMES("component.names"),
 
-
+  BOOTSTRAP_MODULE_CLASS("bootstrap.module.class", "com.microsoft.dhalion.IBootstrapModule$DefaultModule"),
   METRICS_PROVIDER_CLASS("metrics.provider.class");
 
   private final String value;
   private final Object defaultValue;
-
+  
   Key(String value) {
     this(value, null);
   }


### PR DESCRIPTION
**Summary**

Addresses https://github.com/microsoft/Dhalion/issues/52, not being able to customize the injector with additional bindings that are necessary for guice to create the instances properly. Without this, we are relying on having concrete dependencies in constructors.

**Changes**

1. Add a new interface `IBootstrapModule` to fetch the module with additional bindings.
2. Property `bootstrap.module.class` to instantiate the implementation.
3. If this property is absent, defaults to `DefaultModule` that adds no bindings.